### PR TITLE
[PRC-653] Limit Access to Administrative Interface

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -36,7 +36,7 @@ export class HeaderComponent {
   renderMenu(route: String) {
     // Sysadmin's get administration.
     if (route === 'administration') {
-      return (this.jwt && this.jwt.scopes.find(x => x === 'sysadmin'));
+      return (this.jwt && this.jwt.scopes.find(x => x === 'sysadmin') && this.jwt.username === 'admin');
     }
   }
 }


### PR DESCRIPTION
Removing the administrative menu item if the user name does not match 'admin'