### PR TITLE
PRC-773, PRC-776: updates to application service

### DIFF
--- a/src/app/applications/application-add-edit/application-add-edit.component.html
+++ b/src/app/applications/application-add-edit/application-add-edit.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="title-container">
       <div class="title-container__title">
-        <h1><span class="text-muted">Crown land File: {{application.cl_file}} &nbsp;&rsaquo;&nbsp; </span>
+        <h1><span class="text-muted">Crown land File: {{application['clFile']}} &nbsp;&rsaquo;&nbsp; </span>
           {{!application._id ? 'Create' : 'Edit'}} Application
         </h1>
         <span class="title-container__sub text-muted">Disposition Transaction: {{application.tantalisID}}</span>

--- a/src/app/applications/application-add-edit/application-add-edit.component.ts
+++ b/src/app/applications/application-add-edit/application-add-edit.component.ts
@@ -427,8 +427,8 @@ export class ApplicationAddEditComponent implements OnInit, OnDestroy {
           alert('Uh-oh, couldn\'t add application, part 2');
         },
         () => { // onCompleted
-          // reload all data
-          this.applicationService.getById(application2._id, true)
+          // reload app with decision for next step
+          this.applicationService.getById(application2._id, { getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application3 => {
@@ -599,8 +599,8 @@ export class ApplicationAddEditComponent implements OnInit, OnDestroy {
           alert('Uh-oh, couldn\'t save application, part 1');
         },
         () => { // onCompleted
-          // reload all data
-          this.applicationService.getById(this.application._id, true)
+          // reload app with documents, current period and decision for next step
+          this.applicationService.getById(this.application._id, { getDocuments: true, getCurrentPeriod: true, getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application2 => {
@@ -666,8 +666,8 @@ export class ApplicationAddEditComponent implements OnInit, OnDestroy {
           alert('Uh-oh, couldn\'t save application, part 2');
         },
         () => { // onCompleted
-          // reload all data
-          this.applicationService.getById(application2._id, true)
+          // reload app with decision for next step
+          this.applicationService.getById(application2._id, { getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application3 => {

--- a/src/app/applications/application-detail/application-detail.component.html
+++ b/src/app/applications/application-detail/application-detail.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="title-container">
       <div class="title-container__title">
-        <h1>Crown land File: {{application.cl_file}}</h1>
+        <h1>Crown land File: {{application['clFile']}}</h1>
         <span class="title-container__sub text-muted">Disposition Transaction: {{application.tantalisID}}</span>
       </div>
       <div class="title-container__actions">
@@ -186,7 +186,7 @@
             <ul class="nv-list">
               <li>
                 <span class="name">Status:</span>
-                <span class="value">{{application['cpStatus']}}</span>
+                <span class="value">{{application.cpStatus}}</span>
               </li>
               <li>
                 <span class="name">Start Date:</span>

--- a/src/app/applications/application-detail/application-detail.component.ts
+++ b/src/app/applications/application-detail/application-detail.component.ts
@@ -258,7 +258,7 @@ export class ApplicationDetailComponent implements OnInit, OnDestroy {
         () => { // onCompleted
           this.snackBarRef = this.snackBar.open('Application published...', null, { duration: 2000 });
           // reload all data
-          this.applicationService.getById(this.application._id, true)
+          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application => {
@@ -328,7 +328,7 @@ export class ApplicationDetailComponent implements OnInit, OnDestroy {
         () => { // onCompleted
           this.snackBarRef = this.snackBar.open('Application unpublished...', null, { duration: 2000 });
           // reload all data
-          this.applicationService.getById(this.application._id, true)
+          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application => {

--- a/src/app/applications/application-list/application-list.component.html
+++ b/src/app/applications/application-list/application-list.component.html
@@ -39,7 +39,7 @@
             <th class="application-table__status-col sortable" (click)="sort('appStatus')">Status
               <i class="sort" [ngClass]="{'sort-asc': (column == 'appStatus' && direction < 0), 'sort-desc': (column == 'appStatus' && direction > 0) }" aria-hidden="true"></i>
             </th>
-            <th class="application-table__commenting-col sortable" (click)="sort('appStatus')">PRC Status
+            <th class="application-table__commenting-col sortable" (click)="sort('cpStatus')">PRC Status
               <i class="sort" [ngClass]="{'sort-asc': (column == 'cpStatus' && direction < 0), 'sort-desc': (column == 'cpStatus' && direction > 0) }" aria-hidden="true"></i>
             </th>
           </tr>
@@ -56,11 +56,11 @@
                   </a>
                   <span class="accordion__collapse-header--column application-table__name-col">{{item.client || '-'}}</span>
                   <span class="accordion__collapse-header--column application-table__cl_file-col">
-                    <a [routerLink]="['/a', item._id]">{{item.cl_file || '-'}}</a>
+                    <a [routerLink]="['/a', item._id]">{{item['clFile'] || '-'}}</a>
                   </span>
                   <span class="accordion__collapse-header--column application-table__purpose-col">{{item.purpose || '-'}} / {{item.subpurpose || '-'}}</span>
-                  <span class="accordion__collapse-header--column application-table__region-col">{{applicationService.getRegionString(applicationService.getRegionCode(item.businessUnit)) || '-'}}</span>
-                  <span class="accordion__collapse-header--column application-table__status-col">{{item.status || '-'}}</span>
+                  <span class="accordion__collapse-header--column application-table__region-col">{{item.region || '-'}}</span>
+                  <span class="accordion__collapse-header--column application-table__status-col">{{item.appStatus || '-'}}</span>
                   <span class="accordion__collapse-header--column application-table__commenting-col">{{item.cpStatus}}</span>
                 </div>
 
@@ -79,8 +79,8 @@
                         <li class="p-0" *ngIf="item.currentPeriod">
                           <span class="name">Comment Period Dates:</span>
                           <span class="value">{{item.currentPeriod.startDate | date:'mediumDate'}} to {{item.currentPeriod.endDate | date:'mediumDate'}}
-                            <span *ngIf="item['daysRemaining']">
-                              &nbsp;({{item['daysRemaining'] + (item['daysRemaining'] === 1 ? ' day ' : ' days ') + 'remaining'}})
+                            <span *ngIf="item.currentPeriod['daysRemaining']">
+                              &nbsp;({{item.currentPeriod['daysRemaining'] + (item.currentPeriod['daysRemaining'] === 1 ? ' day ' : ' days ') + 'remaining'}})
                             </span>
                           </span>
                         </li>

--- a/src/app/applications/application-list/application-list.component.ts
+++ b/src/app/applications/application-list/application-list.component.ts
@@ -9,7 +9,6 @@ import { Application } from 'app/models/application';
 import { ApiService } from 'app/services/api';
 import { ApplicationService } from 'app/services/application.service';
 import { CommentPeriodService } from 'app/services/commentperiod.service';
-import { CommentService } from 'app/services/comment.service';
 
 @Component({
   selector: 'app-application-list',
@@ -32,8 +31,7 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
     private router: Router,
     private route: ActivatedRoute,
     private applicationService: ApplicationService,
-    public commentPeriodService: CommentPeriodService,
-    private commentService: CommentService
+    public commentPeriodService: CommentPeriodService
   ) { }
 
   ngOnInit() {
@@ -41,8 +39,6 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
     if (!this.api.ensureLoggedIn()) {
       return false;
     }
-
-    const self = this;
 
     // get optional query parameters
     this.route.queryParamMap
@@ -55,27 +51,11 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
       });
 
     // get data
-    this.applicationService.getAll()
+    this.applicationService.getAll({ getCurrentPeriod: true, getNumComments: true })
       .takeUntil(this.ngUnsubscribe)
       .subscribe(applications => {
         this.loading = false;
         this.applications = applications;
-        applications.forEach(app => {
-          self.commentPeriodService.getAllByApplicationId(app._id)
-          .takeUntil(this.ngUnsubscribe)
-          .subscribe(cp => {
-            app.currentPeriod = cp[0];
-            app['cpStatus'] = self.commentPeriodService.getStatus(app.currentPeriod);
-
-            if (app.currentPeriod && app.currentPeriod._id) {
-              self.commentService.getCommentsByPeriodId(app.currentPeriod._id)
-              .takeUntil(this.ngUnsubscribe)
-              .subscribe(comments => {
-                app['numComments'] = comments.length;
-              });
-            }
-          });
-        });
       }, error => {
         this.loading = false;
         console.log(error);

--- a/src/app/applications/application-resolver.service.ts
+++ b/src/app/applications/application-resolver.service.ts
@@ -43,6 +43,6 @@ export class ApplicationDetailResolver implements Resolve<Application> {
     }
 
     // view/edit existing application
-    return this.applicationService.getById(appId);
+    return this.applicationService.getById(appId, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true });
   }
 }

--- a/src/app/models/application.ts
+++ b/src/app/models/application.ts
@@ -22,9 +22,9 @@ export class Application {
   centroid: Array<number> = []; // [lng, lat]
   cl_file: number;
   client: string;
-  description: string;
+  description: string = null;
   internal: Internal;
-  legalDescription: string;
+  legalDescription: string = null;
   location: string;
   name: string; // MAY BE OBSOLETE
   publishDate: Date;
@@ -37,6 +37,8 @@ export class Application {
   type: string;
 
   region: string; // region code derived from Business Unit
+  appStatus: string; // user-friendly application status
+  cpStatus: string; // user-friendly comment period status
 
   isPublished = false; // depends on tags; see below
 
@@ -54,9 +56,7 @@ export class Application {
     this.businessUnit            = obj && obj.businessUnit            || null;
     this.cl_file                 = obj && obj.cl_file                 || null;
     this.client                  = obj && obj.client                  || null;
-    this.description             = obj && obj.description             || null;
-    this.internal                = obj && obj.internal                || new Internal(obj.internal);
-    this.legalDescription        = obj && obj.legalDescription        || null;
+    this.internal                = obj && obj.internal                || new Internal();
     this.location                = obj && obj.location                || null;
     this.name                    = obj && obj.name                    || null;
     this.publishDate             = obj && obj.publishDate             || null;
@@ -69,10 +69,38 @@ export class Application {
     this.type                    = obj && obj.type                    || null;
 
     this.region                  = obj && obj.region                  || null;
+    this.appStatus               = obj && obj.appStatus               || null;
+    this.cpStatus                = obj && obj.cpStatus                || null;
 
+    this.currentPeriod           = obj && obj.currentPeriod           || null;
+    this.decision                = obj && obj.decision                || null;
+
+    // replace \\n (JSON format) with newlines
+    if (obj && obj.description) {
+      this.description = obj.description.replace(/\\n/g, '\n');
+    }
+    if (obj && obj.legalDescription) {
+      this.legalDescription = obj.legalDescription.replace(/\\n/g, '\n');
+    }
+
+    // copy centroid
     if (obj && obj.centroid) {
       obj.centroid.forEach(num => {
         this.centroid.push(num);
+      });
+    }
+
+    // copy documents
+    if (obj && obj.documents) {
+      obj.documents.forEach(doc => {
+        this.documents.push(doc);
+      });
+    }
+
+    // copy features
+    if (obj && obj.features) {
+      obj.features.forEach(feature => {
+        this.features.push(feature);
       });
     }
 

--- a/src/app/models/commentperiod.ts
+++ b/src/app/models/commentperiod.ts
@@ -26,7 +26,12 @@ export class CommentPeriod {
     this.endDate      = obj && new Date(obj.endDate)   || null;
     this.internal     = obj && obj.internal            || new Internal();
 
-    // Wrap isPublished around the tags we receive for this object.
+    // replace \\n (JSON format) with newlines
+    if (obj && obj.description) {
+      this.description = obj.description.replace(/\\n/g, '\n');
+    }
+
+    // wrap isPublished around the tags we receive for this object
     if (obj && obj.tags) {
       const self = this;
       _.each(obj.tags, function (tag) {
@@ -34,10 +39,6 @@ export class CommentPeriod {
           self.isPublished = true;
         }
       });
-    }
-
-    if (obj && obj.description) {
-      this.description = obj.description.replace(/\\n/g, '\n');
     }
   }
 }

--- a/src/app/models/decision.ts
+++ b/src/app/models/decision.ts
@@ -7,7 +7,7 @@ export class Decision {
   _application: string; // objectid -> Application
   code: string;
   name: string;
-  description: string;
+  description: string = null;
 
   documents: Array<Document> = [];
   isPublished = false;
@@ -18,8 +18,13 @@ export class Decision {
     this._application = obj && obj._application || null;
     this.code         = obj && obj.code         || null;
     this.name         = obj && obj.name         || null;
-    this.description  = obj && obj.description  || null;
 
+    // replace \\n (JSON format) with newlines
+    if (obj && obj.description) {
+      this.description = obj.description.replace(/\\n/g, '\n');
+    }
+
+    // copy documents
     if (obj && obj.documents) {
       obj.documents.forEach(doc => {
         this.documents.push(doc);

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -92,14 +92,14 @@ export class SearchComponent implements OnInit, OnDestroy {
                 // if app is in PRC, query application data to update UI
                 if (_.includes(search.sidsFound, key)) {
                   value[0].loaded = false;
-                  self.applicationService.getByTantalisID(+key, true)
+                  self.applicationService.getByTantalisID(+key, { getCurrentPeriod: true, getNumComments: true })
                     .takeUntil(self.ngUnsubscribe)
                     .subscribe(
                       application => {
                         value[0].loaded = true;
                         if (application) {
                           // display PRC status from application
-                          value[0].prcStatus = application['appStatus'];
+                          value[0].prcStatus = application.appStatus;
                           value[0].app = application;
                           // Force change detection since we changed a bound property after the normal check cycle and outside anything
                           // that would trigger a CD cycle - this will eliminate the error we get when running in dev mode.

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -167,7 +167,7 @@ export class ApiService {
       'tenureStage',
       'type'
     ];
-    let queryString = 'application?isDeleted=false&fields=';
+    let queryString = 'application?isDeleted=false&pageNum=0&pageSize=1000000&fields='; // max 1M records
     _.each(fields, function (f) {
       queryString += f + '|';
     });


### PR DESCRIPTION
PRC-773: added missing things to get Application
- overrode pagination when retrieving applications (max 1M results)
- fixed getByTantalisID() to get extra app data
- added missing comment count
- added missing \\n replacement for descriptions
- added missing 7-digit CL code
- updated headers to display modified CL code
- misc cleanup

PRC-776: parameterized application 'get' functions + model cleanup
- refactored code to use common function to retrieve extra app data
- parameterized application 'get' functions to retrieve only required extra data
- removed obsolete app caching
- moved some property code to models
- added 'user-friendly display' fields to app model for better typing
- added missing document and features copy code to app model
- a bit of cleanup