### PR TITLE
PRC-788: clean up api and services (see details)

### DIFF
--- a/src/app/applications/application-aside/application-aside.component.ts
+++ b/src/app/applications/application-aside/application-aside.component.ts
@@ -180,7 +180,7 @@ export class ApplicationAsideComponent implements OnInit, OnChanges, OnDestroy {
   public drawMap(app: Application) {
     if (app.tantalisID) {
       const self = this; // for closure function below
-      this.featureService.getByDTID(app.tantalisID)
+      this.featureService.getByTantalisId(app.tantalisID)
         .takeUntil(this.ngUnsubscribe)
         .subscribe(
           features => {

--- a/src/app/applications/application-detail/application-detail.component.html
+++ b/src/app/applications/application-detail/application-detail.component.html
@@ -106,17 +106,17 @@
                   <ul class="doc-list">
                     <li *ngFor="let doc of application.documents">
                       <span class="cell icon">
-                        <i class="material-icons link" (click)="api.openFile(doc)">
+                        <i class="material-icons link" (click)="api.openDocument(doc)">
                           insert_drive_file
                         </i>
                       </span>
                       <span class="cell name" [title]="doc.displayName || ''">
                         <span class="cell__txt-content">
-                          <a (click)="api.openFile(doc)">{{doc.documentFileName}}</a>
+                          <a (click)="api.openDocument(doc)">{{doc.documentFileName}}</a>
                         </span>
                       </span>
                       <span class="cell actions">
-                      <button class="btn btn-icon" type="button" title="Download this document" (click)="api.downloadFile(doc)">
+                      <button class="btn btn-icon" type="button" title="Download this document" (click)="api.downloadDocument(doc)">
                           <i class="material-icons">file_download</i>
                         </button>
                       </span>
@@ -204,7 +204,7 @@
             <div class="btn-container">
               <button class="cta-btn btn btn-sm btn-outline-primary" type="button"
                 [routerLink]="['/comments', application._id]">
-                Review Comments ({{application['numComments']}})
+                Review Comments<span *ngIf="application['numComments'] >= 0">&nbsp;({{application['numComments']}})</span>
               </button>
             </div>
           </div>
@@ -220,17 +220,17 @@
               <ul class="doc-list">
                 <li *ngFor="let doc of application.decision.documents">
                   <span class="cell icon">
-                    <i class="material-icons link" (click)="api.openFile(doc)">
+                    <i class="material-icons link" (click)="api.openDocument(doc)">
                       insert_drive_file
                     </i>
                   </span>
                   <span class="cell name" [title]="doc.displayName || ''">
                       <span class="cell__txt-content">
-                        <a (click)="api.openFile(doc)">{{doc.documentFileName}}</a>
+                        <a (click)="api.openDocument(doc)">{{doc.documentFileName}}</a>
                       </span>
                   </span>
                   <span class="cell actions">
-                    <button class="btn btn-icon" title="Download this document" (click)="api.downloadFile(doc)">
+                    <button class="btn btn-icon" title="Download this document" (click)="api.downloadDocument(doc)">
                       <i class="material-icons">file_download</i>
                     </button>
                   </span>

--- a/src/app/applications/application-detail/application-detail.component.ts
+++ b/src/app/applications/application-detail/application-detail.component.ts
@@ -258,7 +258,7 @@ export class ApplicationDetailComponent implements OnInit, OnDestroy {
         () => { // onCompleted
           this.snackBarRef = this.snackBar.open('Application published...', null, { duration: 2000 });
           // reload all data
-          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true })
+          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application => {
@@ -328,7 +328,7 @@ export class ApplicationDetailComponent implements OnInit, OnDestroy {
         () => { // onCompleted
           this.snackBarRef = this.snackBar.open('Application unpublished...', null, { duration: 2000 });
           // reload all data
-          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true })
+          this.applicationService.getById(this.application._id, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getDecision: true })
             .takeUntil(this.ngUnsubscribe)
             .subscribe(
               application => {

--- a/src/app/applications/application-list/application-list.component.ts
+++ b/src/app/applications/application-list/application-list.component.ts
@@ -51,7 +51,7 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
       });
 
     // get data
-    this.applicationService.getAll({ getCurrentPeriod: true, getNumComments: true })
+    this.applicationService.getAll({ getCurrentPeriod: true })
       .takeUntil(this.ngUnsubscribe)
       .subscribe(applications => {
         this.loading = false;

--- a/src/app/applications/application-resolver.service.ts
+++ b/src/app/applications/application-resolver.service.ts
@@ -20,7 +20,7 @@ export class ApplicationDetailResolver implements Resolve<Application> {
 
     if (appId === '0') {
       // create new application
-      const app = new Application({
+      const application = new Application({
         purpose: route.queryParamMap.get('purpose'),
         subpurpose: route.queryParamMap.get('subpurpose'),
         type: route.queryParamMap.get('type'),
@@ -35,14 +35,20 @@ export class ApplicationDetailResolver implements Resolve<Application> {
       });
 
       // 7-digit CL File number for display
-      if (app.cl_file) {
-        app['clFile'] = app.cl_file.toString().padStart(7, '0');
+      if (application.cl_file) {
+        application['clFile'] = application.cl_file.toString().padStart(7, '0');
       }
 
-      return of(app);
+      // user-friendly application status
+      application.appStatus = this.applicationService.getStatusString(this.applicationService.getStatusCode(application.status));
+
+      // derive region code
+      application.region = this.applicationService.getRegionCode(application.businessUnit);
+
+      return of(application);
     }
 
     // view/edit existing application
-    return this.applicationService.getById(appId, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getNumComments: true, getDecision: true });
+    return this.applicationService.getById(appId, { getFeatures: true, getDocuments: true, getCurrentPeriod: true, getDecision: true });
   }
 }

--- a/src/app/applications/select-organization/select-organization.component.ts
+++ b/src/app/applications/select-organization/select-organization.component.ts
@@ -36,20 +36,15 @@ export class SelectOrganizationComponent extends DialogComponent<DataModel, stri
   }
 
   ngOnInit() {
-    const self = this;
     this.searchService.getClientsByDTID(this.dispositionId)
       .subscribe(
-        data => {
-          _.each(data, function (i) {
-            self.clients.push(new Client(i));
-            // Pre-select the existing clients if they're in the list
-            // if (i._id === self.dispositionId) {
-            //   self.selectedClients = i;
-            // }
-          });
+        clients => {
           this.isLoading = false;
+          this.clients = clients;
         },
         error => {
+          this.isLoading = false;
+          console.log('error =', error);
           this.api.ensureLoggedIn();
         });
   }

--- a/src/app/models/application.ts
+++ b/src/app/models/application.ts
@@ -49,31 +49,32 @@ export class Application {
   features: Array<Feature> = [];
 
   constructor(obj?: any) {
-    this._id                     = obj && obj._id                     || null;
+    this._id                     = obj && obj._id           || null;
 
-    this.agency                  = obj && obj.agency                  || null;
-    this.areaHectares            = obj && obj.areaHectares            || null;
-    this.businessUnit            = obj && obj.businessUnit            || null;
-    this.cl_file                 = obj && obj.cl_file                 || null;
-    this.client                  = obj && obj.client                  || null;
-    this.internal                = obj && obj.internal                || new Internal();
-    this.location                = obj && obj.location                || null;
-    this.name                    = obj && obj.name                    || null;
-    this.publishDate             = obj && obj.publishDate             || null;
-    this.purpose                 = obj && obj.purpose                 || null;
-    this.status                  = obj && obj.status                  || null;
-    this.subpurpose              = obj && obj.subpurpose              || null;
-    this.subtype                 = obj && obj.subtype                 || null;
-    this.tantalisID              = obj && obj.tantalisID              || null; // not zero
-    this.tenureStage             = obj && obj.tenureStage             || null;
-    this.type                    = obj && obj.type                    || null;
+    this.agency        = obj && obj.agency        || null;
+    this.areaHectares  = obj && obj.areaHectares  || null;
+    this.businessUnit  = obj && obj.businessUnit  || null;
+    this.cl_file       = obj && obj.cl_file       || null;
+    this.client        = obj && obj.client        || null;
+    this.location      = obj && obj.location      || null;
+    this.name          = obj && obj.name          || null;
+    this.publishDate   = obj && obj.publishDate   || null;
+    this.purpose       = obj && obj.purpose       || null;
+    this.status        = obj && obj.status        || null;
+    this.subpurpose    = obj && obj.subpurpose    || null;
+    this.subtype       = obj && obj.subtype       || null;
+    this.tantalisID    = obj && obj.tantalisID    || null; // not zero
+    this.tenureStage   = obj && obj.tenureStage   || null;
+    this.type          = obj && obj.type          || null;
 
-    this.region                  = obj && obj.region                  || null;
-    this.appStatus               = obj && obj.appStatus               || null;
-    this.cpStatus                = obj && obj.cpStatus                || null;
+    this.region        = obj && obj.region        || null;
+    this.appStatus     = obj && obj.appStatus     || null;
+    this.cpStatus      = obj && obj.cpStatus      || null;
 
-    this.currentPeriod           = obj && obj.currentPeriod           || null;
-    this.decision                = obj && obj.decision                || null;
+    this.currentPeriod = obj && obj.currentPeriod || null;
+    this.decision      = obj && obj.decision      || null;
+
+    this.internal      = new Internal(obj && obj.internal || null);
 
     // replace \\n (JSON format) with newlines
     if (obj && obj.description) {
@@ -85,33 +86,33 @@ export class Application {
 
     // copy centroid
     if (obj && obj.centroid) {
-      obj.centroid.forEach(num => {
+      for (const num of obj.centroid) {
         this.centroid.push(num);
-      });
+      }
     }
 
     // copy documents
     if (obj && obj.documents) {
-      obj.documents.forEach(doc => {
+      for (const doc of obj.documents) {
         this.documents.push(doc);
-      });
+      }
     }
 
     // copy features
     if (obj && obj.features) {
-      obj.features.forEach(feature => {
+      for (const feature of obj.features) {
         this.features.push(feature);
-      });
+      }
     }
 
     // wrap isPublished around the tags we receive for this object
     if (obj && obj.tags) {
-      const self = this;
-      _.each(obj.tags, function (tag) {
+      for (const tag of obj.tags) {
         if (_.includes(tag, 'public')) {
-          self.isPublished = true;
+          this.isPublished = true;
+          break;
         }
-      });
+      }
     }
   }
 }

--- a/src/app/models/client.ts
+++ b/src/app/models/client.ts
@@ -1,23 +1,23 @@
 export class Client {
-    ORGANIZATIONS_LEGAL_NAME: string;
-    INDIVIDUALS_FIRST_NAME: string;
-    INDIVIDUALS_LAST_NAME: string;
-    CITY: string;
-    PROVINCE_ABBREVIATION: string;
-    STATE_ABBREVIATION: string;
-    COUNTRY: string;
-    DISPOSITION_TRANSACTION_SID: number;
-    INTERESTED_PARTY_SID: number;
+  CITY: string;
+  COUNTRY: string;
+  DISPOSITION_TRANSACTION_SID: number;
+  INDIVIDUALS_FIRST_NAME: string;
+  INDIVIDUALS_LAST_NAME: string;
+  INTERESTED_PARTY_SID: number;
+  ORGANIZATIONS_LEGAL_NAME: string;
+  PROVINCE_ABBREVIATION: string;
+  STATE_ABBREVIATION: string;
 
-    constructor(obj?: any) {
-        this.ORGANIZATIONS_LEGAL_NAME       = obj && obj.ORGANIZATIONS_LEGAL_NAME       || null;
-        this.INDIVIDUALS_FIRST_NAME         = obj && obj.INDIVIDUALS_FIRST_NAME         || null;
-        this.INDIVIDUALS_LAST_NAME          = obj && obj.INDIVIDUALS_LAST_NAME          || null;
-        this.CITY                           = obj && obj.CITY                           || null;
-        this.PROVINCE_ABBREVIATION          = obj && obj.PROVINCE_ABBREVIATION          || null;
-        this.STATE_ABBREVIATION             = obj && obj.STATE_ABBREVIATION             || null;
-        this.COUNTRY                        = obj && obj.COUNTRY                        || null;
-        this.DISPOSITION_TRANSACTION_SID    = obj && obj.DISPOSITION_TRANSACTION_SID    || null;
-        this.INTERESTED_PARTY_SID           = obj && obj.INTERESTED_PARTY_SID           || null;
-    }
+  constructor(obj?: any) {
+    this.CITY                           = obj && obj.CITY                           || null;
+    this.COUNTRY                        = obj && obj.COUNTRY                        || null;
+    this.DISPOSITION_TRANSACTION_SID    = obj && obj.DISPOSITION_TRANSACTION_SID    || null;
+    this.INDIVIDUALS_FIRST_NAME         = obj && obj.INDIVIDUALS_FIRST_NAME         || null;
+    this.INDIVIDUALS_LAST_NAME          = obj && obj.INDIVIDUALS_LAST_NAME          || null;
+    this.INTERESTED_PARTY_SID           = obj && obj.INTERESTED_PARTY_SID           || null;
+    this.ORGANIZATIONS_LEGAL_NAME       = obj && obj.ORGANIZATIONS_LEGAL_NAME       || null;
+    this.PROVINCE_ABBREVIATION          = obj && obj.PROVINCE_ABBREVIATION          || null;
+    this.STATE_ABBREVIATION             = obj && obj.STATE_ABBREVIATION             || null;
+  }
 }

--- a/src/app/models/commentperiod.ts
+++ b/src/app/models/commentperiod.ts
@@ -3,19 +3,24 @@ import * as _ from 'lodash';
 class Internal {
   notes: string;
   _addedBy: string;
+
+  constructor(obj?: any) {
+    this.notes    = obj && obj.notes    || null;
+    this._addedBy = obj && obj._addedBy || null;
+  }
 }
 
 export class CommentPeriod {
   _id: string;
   _addedBy: string;
   _application: string;
-  description: string;
+  description: string = null;
   code: string;
   startDate: Date;
   endDate: Date;
   internal: Internal; // OBSOLETE BUT API V1 EXPECTS IT - REMOVE LATER
 
-  isPublished = false;
+  isPublished = false; // depends on tags; see below
 
   constructor(obj?: any) {
     this._id          = obj && obj._id                 || null;
@@ -24,7 +29,8 @@ export class CommentPeriod {
     this.code         = obj && obj.code                || null;
     this.startDate    = obj && new Date(obj.startDate) || null;
     this.endDate      = obj && new Date(obj.endDate)   || null;
-    this.internal     = obj && obj.internal            || new Internal();
+
+    this.internal     = new Internal(obj && obj.internal || null);
 
     // replace \\n (JSON format) with newlines
     if (obj && obj.description) {
@@ -33,12 +39,12 @@ export class CommentPeriod {
 
     // wrap isPublished around the tags we receive for this object
     if (obj && obj.tags) {
-      const self = this;
-      _.each(obj.tags, function (tag) {
+      for (const tag of obj.tags) {
         if (_.includes(tag, 'public')) {
-          self.isPublished = true;
+          this.isPublished = true;
+          break;
         }
-      });
+      }
     }
   }
 }

--- a/src/app/models/decision.ts
+++ b/src/app/models/decision.ts
@@ -10,7 +10,8 @@ export class Decision {
   description: string = null;
 
   documents: Array<Document> = [];
-  isPublished = false;
+
+  isPublished = false; // depends on tags; see below
 
   constructor(obj?: any) {
     this._id          = obj && obj._id          || null;
@@ -26,19 +27,19 @@ export class Decision {
 
     // copy documents
     if (obj && obj.documents) {
-      obj.documents.forEach(doc => {
+      for (const doc of obj.documents) {
         this.documents.push(doc);
-      });
+      }
     }
 
     // wrap isPublished around the tags we receive for this object
     if (obj && obj.tags) {
-      const self = this;
-      _.each(obj.tags, function (tag) {
+      for (const tag of obj.tags) {
         if (_.includes(tag, 'public')) {
-          self.isPublished = true;
+          this.isPublished = true;
+          break;
         }
-      });
+      }
     }
   }
 }

--- a/src/app/models/document.ts
+++ b/src/app/models/document.ts
@@ -13,7 +13,7 @@ export class Document {
   internalMime: string;
   tags: Array<string>;
 
-  isPublished = false;
+  isPublished = false; // depends on tags; see below
 
   constructor(obj?: any) {
     this._id              = obj && obj._id              || null;
@@ -27,14 +27,14 @@ export class Document {
     this.isDeleted        = obj && obj.isDeleted        || null;
     this.internalMime     = obj && obj.internalMime     || null;
 
-    // Wrap isPublished around the tags we receive for this object.
+    // wrap isPublished around the tags we receive for this object
     if (obj && obj.tags) {
-      const self = this;
-      _.each(obj.tags, function (tag) {
+      for (const tag of obj.tags) {
         if (_.includes(tag, 'public')) {
-          self.isPublished = true;
+          this.isPublished = true;
+          break;
         }
-      });
+      }
     }
   }
 }

--- a/src/app/models/organization.ts
+++ b/src/app/models/organization.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 export class Organization {
   _id: string;
   _addedBy: string;
@@ -18,6 +20,8 @@ export class Organization {
   postal: string;
   country: string;
 
+  isPublished = false; // depends on tags; see below
+
   constructor(obj?: any) {
     this._id            = obj && obj._id            || null;
     this._addedBy       = obj && obj._addedBy       || null;
@@ -36,5 +40,15 @@ export class Organization {
     this.postal         = obj && obj.postal         || null;
     this.country        = obj && obj.country        || null;
     this.parentCompany  = obj && obj.parentCompany  || null;
+
+    // wrap isPublished around the tags we receive for this object
+    if (obj && obj.tags) {
+      for (const tag of obj.tags) {
+        if (_.includes(tag, 'public')) {
+          this.isPublished = true;
+          break;
+        }
+      }
+    }
   }
 }

--- a/src/app/models/search.ts
+++ b/src/app/models/search.ts
@@ -25,25 +25,32 @@ export class SearchResults {
     this.status        = search && search.status        || null;
     this.hostname      = hostname;
 
+    // copy features
     if (search && search.features) {
-      search.features.forEach(feature => {
+      for (const feature of search.features) {
         this.features.push(feature);
-      });
+      }
     }
 
+    // copy sidsFound
     if (search && search.sidsFound) {
-      search.sidsFound.forEach(sidFound => {
-        this.sidsFound.push(sidFound);
-      });
+      for (const sid of search.sidsFound) {
+        this.sidsFound.push(sid);
+      }
     }
   }
 }
 
 export class SearchArray {
-  items: Array<SearchResults>;
+  items: Array<SearchResults> = [];
 
   constructor(obj?: any) {
-    this.items = obj && obj.items || [];
+    // copy items
+    if (obj && obj.items) {
+      for (const item of obj.items) {
+        this.items.push(item);
+      }
+    }
   }
 
   sort() {
@@ -76,10 +83,11 @@ export class SearchTerms {
     this.dateStart = obj && obj.dateStart || null;
     this.dateEnd   = obj && obj.dateEnd   || null;
 
+    // copy organizations
     if (obj && obj.organizations) {
-      obj.organizations.forEach(org => {
+      for (const org of obj.organizations) {
         this.organizations.push(org);
-      });
+      }
     }
   }
 

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 export class User {
   _id: string;
   username: string;
@@ -5,7 +7,10 @@ export class User {
   firstName: string;
   lastName: string;
   password: string;
-  roles: Array<Array<string>>;
+
+  roles: Array<Array<string>> = [[]];
+
+  isPublished = false; // depends on tags; see below
 
   constructor(obj?: any) {
     this._id         = obj && obj._id          || null;
@@ -14,6 +19,20 @@ export class User {
     this.firstName   = obj && obj.firstName    || null;
     this.lastName    = obj && obj.lastName     || null;
     this.password    = obj && obj.password     || null;
-    this.roles       = obj && obj.roles        || null;
+
+    // copy roles
+    if (obj && obj.roles) {
+      this.roles = _.cloneDeep(obj.roles);
+    }
+
+    // wrap isPublished around the tags we receive for this object
+    if (obj && obj.tags) {
+      for (const tag of obj.tags) {
+        if (_.includes(tag, 'public')) {
+          this.isPublished = true;
+          break;
+        }
+      }
+    }
   }
 }

--- a/src/app/not-authorized/not-authorized.component.ts
+++ b/src/app/not-authorized/not-authorized.component.ts
@@ -9,6 +9,6 @@ export class NotAuthorizedComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
+
 }

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -83,7 +83,7 @@
             <span class="comment-info">
               <span *ngIf="item.app && item.app['numComments'] > 0">
                 <strong>
-                  <a [routerLink]="['/comments', item.app._id]">{{item.app['numComments']}} {{item.app['numComments'] === '1' ? 'comment' : 'comments'}}</a>
+                  <a [routerLink]="['/comments', item.app._id]">{{item.app['numComments']}} {{item.app['numComments'] === 1 ? 'comment' : 'comments'}}</a>
                 </strong>
                 &nbsp;-&nbsp;
               </span>

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatSnackBarRef, SimpleSnackBar, MatSnackBar } from '@angular/material';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs/Subject';
@@ -13,8 +13,7 @@ import { ApiService } from 'app/services/api';
 @Component({
   selector: 'app-search',
   templateUrl: './search.component.html',
-  styleUrls: ['./search.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrls: ['./search.component.scss']
 })
 
 export class SearchComponent implements OnInit, OnDestroy {
@@ -33,7 +32,6 @@ export class SearchComponent implements OnInit, OnDestroy {
     private searchService: SearchService,
     private router: Router,
     private route: ActivatedRoute,
-    private _changeDetectionRef: ChangeDetectorRef,
     // private authenticationService: AuthenticationService,
     private api: ApiService
   ) { }
@@ -93,7 +91,7 @@ export class SearchComponent implements OnInit, OnDestroy {
                 // if app is in PRC, query application data to update UI
                 if (_.includes(search.sidsFound, key)) {
                   value[0].loaded = false;
-                  self.applicationService.getByTantalisID(+key, { getCurrentPeriod: true, getNumComments: true })
+                  self.applicationService.getByTantalisID(+key, { getCurrentPeriod: true })
                     .takeUntil(self.ngUnsubscribe)
                     .subscribe(
                       application => {
@@ -102,9 +100,6 @@ export class SearchComponent implements OnInit, OnDestroy {
                           // display PRC status from application
                           value[0].prcStatus = application.appStatus;
                           value[0].app = application;
-                          // Force change detection since we changed a bound property after the normal check cycle and outside anything
-                          // that would trigger a CD cycle - this will eliminate the error we get when running in dev mode.
-                          self._changeDetectionRef.detectChanges();
                         }
                       },
                       error => {
@@ -127,7 +122,6 @@ export class SearchComponent implements OnInit, OnDestroy {
           this.searching = false;
           this.ranSearch = true;
           this.count = 0;
-          this._changeDetectionRef.detectChanges(); // force change detection
 
           this.snackBarRef = this.snackBar.open('Error searching applications ...', 'RETRY');
           this.snackBarRef.onAction().subscribe(() => this.onSubmit());
@@ -137,7 +131,6 @@ export class SearchComponent implements OnInit, OnDestroy {
           this.searching = false;
           this.ranSearch = true;
           this.count = this.groupByResults.length;
-          this._changeDetectionRef.detectChanges(); // force change detection
         });
   }
 

--- a/src/app/services/commentperiod.service.ts
+++ b/src/app/services/commentperiod.service.ts
@@ -9,6 +9,7 @@ import { CommentPeriod } from 'app/models/commentperiod';
 
 @Injectable()
 export class CommentPeriodService {
+
   // statuses (also used as short strings)
   readonly NOT_STARTED = 'Not Started';
   readonly NOT_OPEN = 'Not Open';
@@ -17,9 +18,6 @@ export class CommentPeriodService {
 
   // use helpers to get these:
   private commentStatuses = [];
-
-  // for caching
-  private commentPeriod: CommentPeriod = null;
 
   constructor(private api: ApiService) {
     // user-friendly strings
@@ -32,6 +30,16 @@ export class CommentPeriodService {
   // get all comment periods for the specified application id
   getAllByApplicationId(appId: string): Observable<CommentPeriod[]> {
     return this.api.getPeriodsByAppId(appId)
+      .map(res => {
+        if (res && res.length > 0) {
+          const periods: Array<CommentPeriod> = [];
+          res.forEach(cp => {
+            periods.push(new CommentPeriod(cp));
+          });
+          return periods;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
@@ -39,11 +47,11 @@ export class CommentPeriodService {
   getById(periodId: string): Observable<CommentPeriod> {
     return this.api.getPeriod(periodId)
       .map(res => {
-        // return the first (only) comment period
-        if (res[0] && res[0].length > 0) {
-          this.commentPeriod = new CommentPeriod(res[0]);
-          return this.commentPeriod;
+        if (res && res.length > 0) {
+          // return the first (only) comment period
+          return new CommentPeriod(res[0]);
         }
+        return null;
       })
       .catch(error => this.api.handleError(error));
   }
@@ -87,7 +95,8 @@ export class CommentPeriodService {
       .catch(error => this.api.handleError(error));
   }
 
-  // returns first period - multiple comment periods are currently not suported
+  // returns first period
+  // multiple comment periods are currently not supported
   getCurrent(periods: CommentPeriod[]): CommentPeriod {
     return (periods.length > 0) ? periods[0] : null;
   }
@@ -126,4 +135,5 @@ export class CommentPeriodService {
   isOpen(period: CommentPeriod): boolean {
     return (this.getStatus(period) === this.commentStatuses[this.OPEN]);
   }
+
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -18,7 +18,7 @@ export class ConfigService {
     // FUTURE: load settings from window.localStorage?
   }
 
-  // called by app constructor - for future use
+  // called by app constructor
   public destroy() {
     // FUTURE: save settings to window.localStorage?
   }

--- a/src/app/services/decision.service.ts
+++ b/src/app/services/decision.service.ts
@@ -1,20 +1,20 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/catch';
 import { of } from 'rxjs';
 import { map, flatMap } from 'rxjs/operators';
-
+import 'rxjs/add/operator/catch';
 import * as _ from 'lodash';
 
 import { ApiService } from './api';
 import { DocumentService } from './document.service';
 import { Decision } from 'app/models/decision';
-import { Document } from 'app/models/document';
+
+interface GetParameters {
+  getDocuments?: boolean;
+}
 
 @Injectable()
 export class DecisionService {
-  private decision: Decision = null;
 
   constructor(
     private api: ApiService,
@@ -22,55 +22,58 @@ export class DecisionService {
   ) { }
 
   // get decision for the specified application id
-  getByApplicationId(appId: string, forceReload: boolean = true): Observable<Decision> {
-    const self = this;
-
-    // Get the decision
-    return this.api.getDecisionByAppId(appId)
+  getByApplicationId(appId: string, params: GetParameters = null): Observable<Decision> {
+    // first get the decision data
+    return this.api.getDecisionsByAppId(appId)
       .pipe(
         flatMap(res => {
           if (res && res.length > 0) {
-            this.decision = new Decision(res[0]);
-            // Then get the documents for this decision
-            return this.documentService.getAllByDecisionId(this.decision._id)
-              .pipe(
-                map(documents => {
-                  _.each(documents, function (d) {
-                    self.decision.documents.push(new Document(d));
-                  });
-                  return this.decision;
-                })
-              );
-          } else {
-            return of(null);
+            // return the first (only) decision
+            const decision = new Decision(res[0]);
+
+            // now get the documents for this decision
+            if (params && params.getDocuments) {
+              return this.documentService.getAllByDecisionId(decision._id)
+                .pipe(
+                  map(documents => {
+                    decision.documents = documents;
+                    return decision;
+                  })
+                );
+            }
+
+            return of(decision);
           }
+          return of(null as Decision);
         })
       )
       .catch(error => this.api.handleError(error));
   }
 
   // get a specific decision by its id
-  getById(decisionId, forceReload: boolean = false): Observable<Decision> {
-    const self = this;
-    if (this.decision && this.decision._id === decisionId && !forceReload) {
-      return of(this.decision);
-    }
-
-    // Get the decision
+  getById(decisionId, params: GetParameters = null): Observable<Decision> {
+    // first get the decision data
     return this.api.getDecision(decisionId)
       .pipe(
         flatMap(res => {
-          this.decision = new Decision(res[0]);
-          // Then get the documents for this decision
-          return this.documentService.getAllByDecisionId(this.decision._id)
-            .pipe(
-              map(documents => {
-                _.each(documents, function (d) {
-                  self.decision.documents.push(new Document(d));
-                });
-                return this.decision;
-              })
-            );
+          if (res && res.length > 0) {
+            // return the first (only) decision
+            const decision = new Decision(res[0]);
+
+            // now get the documents for this decision
+            if (params && params.getDocuments) {
+              return this.documentService.getAllByDecisionId(decision._id)
+                .pipe(
+                  map(documents => {
+                    decision.documents = documents;
+                    return decision;
+                  })
+                );
+            }
+
+            return of(decision);
+          }
+          return of(null as Decision);
         })
       )
       .catch(error => this.api.handleError(error));
@@ -125,4 +128,5 @@ export class DecisionService {
     return this.api.unPublishDecision(decision)
       .catch(error => this.api.handleError(error));
   }
+
 }

--- a/src/app/services/document.service.ts
+++ b/src/app/services/document.service.ts
@@ -2,51 +2,72 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import { of } from 'rxjs';
 
 import { ApiService } from './api';
 import { Document } from 'app/models/document';
 
 @Injectable()
 export class DocumentService {
-  private document: Document = null;
 
   constructor(private api: ApiService) { }
 
   // get all documents for the specified application id
   getAllByApplicationId(id: string): Observable<Document[]> {
     return this.api.getDocumentsByAppId(id)
+      .map(res => {
+        if (res && res.length > 0) {
+          const documents: Array<Document> = [];
+          res.forEach(doc => {
+            documents.push(new Document(doc));
+          });
+          return documents;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
   // get all documents for the specified comment id
   getAllByCommentId(commentId: string): Observable<Document[]> {
     return this.api.getDocumentsByCommentId(commentId)
+      .map(res => {
+        if (res && res.length > 0) {
+          const documents: Array<Document> = [];
+          res.forEach(doc => {
+            documents.push(new Document(doc));
+          });
+          return documents;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
   // get all documents for the specified decision id
   getAllByDecisionId(decisionId: string): Observable<Document[]> {
     return this.api.getDocumentsByDecisionId(decisionId)
+      .map(res => {
+        if (res && res.length > 0) {
+          const documents: Array<Document> = [];
+          res.forEach(doc => {
+            documents.push(new Document(doc));
+          });
+          return documents;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
   // get a specific document by its id
-  getById(documentId: string, forceReload: boolean = false): Observable<Document> {
-    if (this.document && this.document._id === documentId && !forceReload) {
-      return of(this.document);
-    }
-
+  getById(documentId: string): Observable<Document> {
     return this.api.getDocument(documentId)
       .map(res => {
-        // return the first (only) document
-        return new Document(res[0]);
-      })
-      .map((document: Document) => {
-        if (!document) { return null as Document; }
-
-        this.document = document;
-        return this.document;
+        if (res && res.length > 0) {
+          // return the first (only) document
+          return new Document(res[0]);
+        }
+        return null;
       })
       .catch(error => this.api.handleError(error));
   }
@@ -70,4 +91,5 @@ export class DocumentService {
     return this.api.unPublishDocument(document)
       .catch(error => this.api.handleError(error));
   }
+
 }

--- a/src/app/services/feature.service.ts
+++ b/src/app/services/feature.service.ts
@@ -11,13 +11,33 @@ export class FeatureService {
 
   constructor(private api: ApiService) { }
 
-  getByDTID(tantalisId: number): Observable<Feature[]> {
+  getByTantalisId(tantalisId: number): Observable<Feature[]> {
     return this.api.getFeaturesByTantalisId(tantalisId)
+      .map(res => {
+        if (res && res.length > 0) {
+          const features: Array<Feature> = [];
+          res.forEach(f => {
+            features.push(new Feature(f));
+          });
+          return features;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
   getByApplicationId(applicationId: string): Observable<Feature[]> {
     return this.api.getFeaturesByApplicationId(applicationId)
+      .map(res => {
+        if (res && res.length > 0) {
+          const features: Array<Feature> = [];
+          res.forEach(f => {
+            features.push(new Feature(f));
+          });
+          return features;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 

--- a/src/app/services/organization.service.ts
+++ b/src/app/services/organization.service.ts
@@ -9,45 +9,40 @@ import { Organization } from 'app/models/organization';
 
 @Injectable()
 export class OrganizationService {
-  // private organization: Organization = null;
 
   constructor(private api: ApiService) { }
 
   // get all organizations
   getAll(): Observable<Organization[]> {
-    return of(null);
+    return of([] as Organization[]);
 
     // return this.api.getOrganizations()
     //   .map(res => {
-    //     const organizations = res.text() ? res.json() : [];
-    //     organizations.forEach((org, index) => {
-    //       organizations[index] = new Organization(org);
-    //     });
-    //     return organizations;
+    //     if (res && res.length > 0) {
+    //       const organizations: Array<Organization> = [];
+    //       res.forEach(org => {
+    //         organizations.push(new Organization(org));
+    //       });
+    //       return organizations;
+    //     }
+    //     return [];
     //   })
     //   .catch(error => this.api.handleError(error));
   }
 
   // get a specific organization by its id
-  getById(orgId: string, forceReload: boolean = false): Observable<Organization> {
-    return of(null);
-
-    // if (this.organization && this.organization._id === orgId && !forceReload) {
-    //   return of(this.organization);
-    // }
+  getById(orgId: string): Observable<Organization> {
+    return of(null as Organization);
 
     // return this.api.getOrganization(orgId)
     //   .map(res => {
-    //     const organizations = res.text() ? res.json() : [];
-    //     // return the first (only) organization
-    //     return organizations.length > 0 ? new Organization(organizations[0]) : null;
-    //   })
-    //   .map((organization: Organization) => {
-    //     if (!organization) { return null as Organization; }
-
-    //     this.organization = organization;
-    //     return this.organization;
+    //     if (res && res.length > 0) {
+    //       // return the first (only) organization
+    //       return new Organization(res[0]);
+    //     }
+    //     return null;
     //   })
     //   .catch(error => this.api.handleError(error));
   }
+
 }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { merge } from 'rxjs';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/merge';
-import { of } from 'rxjs';
 import * as _ from 'lodash';
 
 import { ApiService } from './api';
@@ -12,22 +11,21 @@ import { Client } from 'app/models/client';
 
 @Injectable()
 export class SearchService {
-  private clients: Array<Client> = null;
 
   constructor(private api: ApiService) { }
 
   // get clients by Disposition Transaction ID
   getClientsByDTID(dtid: number): Observable<Client[]> {
-    this.clients = [];
-    const self = this;
-
     return this.api.getClientsByDTID(dtid)
       .map(res => {
-        _.each(res, function (client) {
-          self.clients.push(new Client(client));
-        });
-        this.clients = self.clients;
-        return this.clients;
+        if (res && res.length > 0) {
+          const clients: Array<Client> = [];
+          res.forEach(c => {
+            clients.push(new Client(c));
+          });
+          return clients;
+        }
+        return [];
       })
       .catch(error => this.api.handleError(error));
   }
@@ -36,19 +34,26 @@ export class SearchService {
   getByClidDtid(keys: string[]): Observable<SearchResults> {
     const observables = keys.map(key => { return this.getByCLID(key); })
       .concat(keys.map(key => { return this.getByDTID(+key); }));
-    return of(null).merge(...observables)
+    return merge(...observables)
       .catch(error => this.api.handleError(error));
   }
 
   // get search results by CL File #
   getByCLID(clid: string): Observable<SearchResults> {
     return this.api.getAppsByCLID(clid)
+      .map(res => {
+        return res ? new SearchResults(res) : null;
+      })
       .catch(error => this.api.handleError(error));
   }
 
   // get search results by Disposition Transaction ID
   getByDTID(dtid: number): Observable<SearchResults> {
     return this.api.getAppsByDTID(dtid)
+      .map(res => {
+        return res ? new SearchResults(res) : null;
+      })
       .catch(error => this.api.handleError(error));
   }
+
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 
 import { ApiService } from './api';
@@ -11,7 +12,17 @@ export class UserService {
   constructor(private api: ApiService) { }
 
   getAll(): Observable<User[]> {
-    return this.api.getAllUsers()
+    return this.api.getUsers()
+      .map(res => {
+        if (res && res.length > 0) {
+          const users: Array<User> = [];
+          res.forEach(user => {
+            users.push(new User(user));
+          });
+          return users;
+        }
+        return [];
+      })
       .catch(error => this.api.handleError(error));
   }
 
@@ -24,4 +35,5 @@ export class UserService {
     return this.api.addUser(user)
       .catch(error => this.api.handleError(error));
   }
+
 }


### PR DESCRIPTION
- added missing new object mappings in services
- moved object mappings into their respective service
- renamed some functions for consistency
- replaced some _.each with .forEach
- removed remaining (obsolete) caching in services
- fixed some model constructors
- added missing isPublished code to models
- get documents for all comments (for easier merge with PR-536)
- refactored api.ts to use template literals and helper function for simpler code
- added missing / fixed incorrect typings
- reduced getAllApplications max records
- count only pending comments
- removed fields for add/save since API ignores them
- removed superfluous getNumComments flag
- removed broken change detection from search page
- added params to comment and decision services
- replaced forEach() with for() in models